### PR TITLE
add category ignore list & refactor tag list emission

### DIFF
--- a/op-export.el
+++ b/op-export.el
@@ -83,19 +83,20 @@ content of the buffer will be converted into html."
   (let* ((filename (buffer-file-name))
          (attr-plist `(:title ,(or (op/read-org-option "TITLE")
                                    "Untitled")
-                              :date ,(fix-timestamp-string
-                                      (or (op/read-org-option "DATE")
-                                          (format-time-string "%Y-%m-%d")))
-                              :mod-date ,(if (not filename)
-                                             (format-time-string "%Y-%m-%d")
-                                           (or (op/git-last-change-date
-                                                op/repository-directory
-                                                filename)
-                                               (format-time-string
-                                                "%Y-%m-%d"
-                                                (nth 5 (file-attributes filename)))))
-                              :description ,(or (op/read-org-option "DESCRIPTION")
-                                                "No Description")))
+                       :date ,(fix-timestamp-string
+                               (or (op/read-org-option "DATE")
+                                   (format-time-string "%Y-%m-%d")))
+                       :mod-date ,(if (not filename)
+                                      (format-time-string "%Y-%m-%d")
+                                    (or (op/git-last-change-date
+                                         op/repository-directory
+                                         filename)
+                                        (format-time-string
+                                         "%Y-%m-%d"
+                                         (nth 5 (file-attributes filename)))))
+                       :description ,(or (op/read-org-option "DESCRIPTION")
+                                         "No Description")
+                       :thumb ,(op/read-org-option "THUMBNAIL")))
          assets-dir post-content
          asset-path asset-abs-path pub-abs-path converted-path
          component-table tags category cat-config)
@@ -121,6 +122,7 @@ content of the buffer will be converted into html."
                                       "\\`/" ""
                                       (plist-get attr-plist :uri)))))
     (when do-pub
+      (princ attr-plist)
       (setq post-content (op/render-content))
       (setq assets-dir (file-name-as-directory
                         (concat (file-name-as-directory pub-root-dir)
@@ -388,7 +390,13 @@ publication directory."
                                         (ht ("post-uri"
                                              (plist-get plist :uri))
                                             ("post-title"
-                                             (plist-get plist :title))))
+                                             (plist-get plist :title))
+                                            ("post-desc"
+                                             (plist-get plist :description))
+                                            ("post-date"
+                                             (plist-get plist :date))
+                                            ("post-thumb"
+                                             (or (plist-get plist :thumb) ""))))
                                     (cdr cell)))))
                   sort-alist)))))
           ("footer"

--- a/op-export.el
+++ b/op-export.el
@@ -83,19 +83,19 @@ content of the buffer will be converted into html."
   (let* ((filename (buffer-file-name))
          (attr-plist `(:title ,(or (op/read-org-option "TITLE")
                                    "Untitled")
-                       :date ,(fix-timestamp-string
-                               (or (op/read-org-option "DATE")
-                                   (format-time-string "%Y-%m-%d")))
-                       :mod-date ,(if (not filename)
-                                      (format-time-string "%Y-%m-%d")
-                                    (or (op/git-last-change-date
-                                         op/repository-directory
-                                         filename)
-                                        (format-time-string
-                                         "%Y-%m-%d"
-                                         (nth 5 (file-attributes filename)))))
-                       :description ,(or (op/read-org-option "DESCRIPTION")
-                                         "No Description")))
+                              :date ,(fix-timestamp-string
+                                      (or (op/read-org-option "DATE")
+                                          (format-time-string "%Y-%m-%d")))
+                              :mod-date ,(if (not filename)
+                                             (format-time-string "%Y-%m-%d")
+                                           (or (op/git-last-change-date
+                                                op/repository-directory
+                                                filename)
+                                               (format-time-string
+                                                "%Y-%m-%d"
+                                                (nth 5 (file-attributes filename)))))
+                              :description ,(or (op/read-org-option "DESCRIPTION")
+                                                "No Description")))
          assets-dir post-content
          asset-path asset-abs-path pub-abs-path converted-path
          component-table tags category cat-config)
@@ -210,6 +210,7 @@ its name and its root folder name under `op/repository-directory'."
              (when (and (not (equal f "."))
                         (not (equal f ".."))
                         (not (equal f ".git"))
+                        (not (member f op/category-ignore-list))
                         (not (equal f "blog"))
                         (file-directory-p
                          (expand-file-name f op/repository-directory)))

--- a/op-template.el
+++ b/op-template.el
@@ -142,6 +142,12 @@ similar to `op/render-header'."
                      (or (op/read-org-option "DATE")
                          (format-time-string "%Y-%m-%d"))))
               (tags (op/read-org-option "TAGS"))
+              (tags (if tags
+                        (mapcar
+                         #'(lambda (tag-name)
+                             (ht ("link" (op/generate-tag-uri tag-name))
+                                 ("name" tag-name)))
+                         (delete "" (mapcar 'trim-string (split-string tags "[:,]+" t))))))
               (category (funcall (or op/retrieve-category-function
                                      op/get-file-category)
                                  filename))
@@ -160,16 +166,13 @@ similar to `op/render-header'."
                                (format-time-string
                                 "%Y-%m-%d"
                                 (nth 5 (file-attributes filename))))))
+             ("tags" tags)
              ("tag-links" (if (not tags) "N/A"
                             (mapconcat
-                             #'(lambda (tag-name)
+                             #'(lambda (tag)
                                  (mustache-render
-                                  "<a href=\"{{link}}\">{{name}}</a>"
-                                  (ht ("link" (op/generate-tag-uri tag-name))
-                                      ("name" tag-name))))
-                             (delete "" (mapcar
-                                         'trim-string
-                                         (split-string tags "[:,]+" t))) ", ")))
+                                  "<a href=\"{{link}}\">{{name}}</a>" tag))
+                             tags " ")))
              ("author" (or (op/read-org-option "AUTHOR")
                            user-full-name
                            "Unknown Author"))

--- a/op-vars.el
+++ b/op-vars.el
@@ -152,6 +152,10 @@ default value is `op/get-file-category'."
     :category-index nil))
   "Configurations for different categories, can and should be customized.")
 
+(defvar op/category-ignore-list
+  '("themes")
+  "Ignore files in these subdirs/categories")
+
 ;;; this variable is deprecated
 (defvar op/default-template-parameters
   (ht ("blog-uri" "/blog/")

--- a/op-vars.el
+++ b/op-vars.el
@@ -154,7 +154,7 @@ default value is `op/get-file-category'."
 
 (defvar op/category-ignore-list
   '("themes" "assets")
-  "Ignore files in these subdirs/categories")
+  "Ignore these subdirs/categories for navigation")
 
 ;;; this variable is deprecated
 (defvar op/default-template-parameters

--- a/op-vars.el
+++ b/op-vars.el
@@ -153,7 +153,7 @@ default value is `op/get-file-category'."
   "Configurations for different categories, can and should be customized.")
 
 (defvar op/category-ignore-list
-  '("themes")
+  '("themes" "assets")
   "Ignore files in these subdirs/categories")
 
 ;;; this variable is deprecated


### PR DESCRIPTION
I wanted to keep my custom theme in the same repo as the blog posts, but the current setup would automatically create an invalid nav item for this `themes` subdir. I added a new var to allow users specifying a black list for these purposes...

Secondly, I was wondering why you need to render the tag list in post-meta via ELisp and not let the template do this link building/formatting. Changed the current logic to emit raw tags in addition to the pre-formatted ones (e.g. I want to be able to style them myself)

Hope these changes make sense and you'll find them useful! Super nice project :)