### PR TITLE
Use as_sitesearch=domain instead of q=site:domain

### DIFF
--- a/themes/mdo/templates/nav.mustache
+++ b/themes/mdo/templates/nav.mustache
@@ -13,7 +13,7 @@
         </ul>
         <form method="get" id="searchform" action="http://www.google.com/search">
           <input type="text" class="field" name="q" id="s" placeholder="Search">
-          <input type="hidden" name="q" value="site:{{site-domain}}">
+          <input type="hidden" name="as_sitesearch" value="{{site-domain}}">
         </form>
         {{#avatar}}
         <img class="avatar" src="{{avatar}}" />

--- a/themes/phaer/templates/nav.mustache
+++ b/themes/phaer/templates/nav.mustache
@@ -9,6 +9,6 @@
   </ul>
   <form method="get" id="search" action="https://duckduckgo.com">
     <input type="text" class="field" name="q" id="s" placeholder="Search">
-    <input type="hidden" name="q" value="site:{{site-domain}}">
+    <input type="hidden" name="as_sitesearch" value="{{site-domain}}">
   </form>
 </header>


### PR DESCRIPTION
Hi @kelvinh,

to initiate a site specific search it is better to use the `as_sitesearch` parameter. Using two query parameters doesn't work, at least in Chrome and Firefox (oddly enough with Safari it worked). 

Ref: <http://moz.com/ugc/the-ultimate-guide-to-the-google-search-parameters>