### PR TITLE
Changing deprecated `flet` (24.3) to `cl-flet`

### DIFF
--- a/op-template.el
+++ b/op-template.el
@@ -122,9 +122,9 @@ similar to `op/render-header'."
                             (or template "post.mustache"))))
    (or param-table
        (ht ("title" (or (op/read-org-option "TITLE") "Untitled"))
-           ("content" (flet ((org-html-fontify-code
-                              (code lang)
-                              (when code (org-html-encode-plain-text code))))
+           ("content" (cl-flet ((org-html-fontify-code
+                                 (code lang)
+                                 (when code (org-html-encode-plain-text code))))
                         (org-export-as 'html nil nil t nil)))))))
 
 (defun op/render-footer (&optional param-table)


### PR DESCRIPTION
This resolved issue #98 on my emacs 24.4

From the `flet` docstring:

```
This macro is obsolete since 24.3;
use either `cl-flet' or `cl-letf'.
```