### PR TITLE
Configureable code highlight render from #88

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,6 +69,9 @@
    : (setq op/personal-duoshuo-shortname "your_duoshuo_shortname")
    : ;;; the configuration below are optional
    : (setq op/personal-google-analytics-id "your_google_analytics_id")
+   : ;;; custom highlight render
+   : (setq op/highlight-render 'js)
+   : ;;; (setq op/highlight-render 'htmlize)
 
 ** Publication
 

--- a/op-template.el
+++ b/op-template.el
@@ -118,24 +118,29 @@ render from a default hash table."
                   (if op/organization (ht ("authors-li" t)) (ht ("avatar" op/personal-avatar))))))))
 
 (defun op/render-content (&optional template param-table)
-  "Render the content on each page. TEMPLATE is the template name for rendering,
+    "Render the content on each page. TEMPLATE is the template name for rendering,
 if it is not set of nil, will use default post.mustache instead. PARAM-TABLE is
-similar to `op/render-header'."
-  (mustache-render
-   (op/get-cache-create
-    (if template
-        (intern (replace-regexp-in-string "\\.mustache$" "-template" template))
-      :post-template)
-    (message (concat "Read " (or template "post.mustache") " from file"))
-    (file-to-string (concat (op/get-template-dir)
-                            (or template "post.mustache"))))
-   (or param-table
-       (ht ("title" (or (op/read-org-option "TITLE") "Untitled"))
-           ("content" (cl-letf (((symbol-function 'org-html-fontify-code)
-                                 #'(lambda (code lang)
-                                     (when code
-                                       (org-html-encode-plain-text code)))))
-                        (org-export-as 'html nil nil t nil)))))))
+similar to `op/render-header'.`op/highlight-render' is `js' or `htmlize'"
+    (mustache-render
+     (op/get-cache-create
+      (if template
+          (intern (replace-regexp-in-string "\\.mustache$" "-template" template))
+        :post-template)
+      (message (concat "Read " (or template "post.mustache") " from file"))
+      (file-to-string (concat (op/get-template-dir)
+                              (or template "post.mustache"))))
+     (or param-table
+         (ht ("title" (or (op/read-org-option "TITLE") "Untitled"))
+             ("content"
+              (cond ((eq op/highlight-render 'js)
+               (progn
+                (cl-letf (((symbol-function'org-html-fontify-code)
+                                       #'(lambda (code lang)
+                                           (when code
+                                             (org-html-encode-plain-text code)))))
+                  (org-export-as'html nil nil t nil))))
+              ((eq op/highlight-render 'htmlize)
+               (org-export-as'html nil nil t nil))))))))
 
 (defun op/render-footer (&optional param-table)
   "Render the footer on each page. PARAM-TABLE is similar to

--- a/op-vars.el
+++ b/op-vars.el
@@ -85,6 +85,11 @@ points to the directory `themes' in org-page installation directory."
   "The theme used for page generation."
   :group 'org-page :type 'symbol)
 
+(defcustom op/highlight-render 'js
+  "Code highlight render"
+  :group 'org-page :type 'symbol)
+
+
 (defcustom op/personal-github-link "https://github.com/kelvinh/org-page"
   "The personal github link."
   :group 'org-page :type 'string)

--- a/org-page.el
+++ b/org-page.el
@@ -156,7 +156,8 @@ perfectly manipulated by org-page."
 `op/site-sub-title': [optional] (but customization recommanded)
 `op/personal-github-link': [optional] (but customization recommended)
 `op/personal-google-analytics-id': [optional] (but customization recommended)
-`op/theme': [optional]"
+`op/theme': [optional]
+`op/highlight-render': [optional](default 'js)"
   (unless (and op/repository-directory
                (file-directory-p op/repository-directory))
     (error "Directory `%s' is not properly configured."
@@ -174,7 +175,10 @@ help configure it manually, usually it should be <org-page directory>/themes/."
               (string-prefix-p "https://" op/site-domain))
     (setq op/site-domain (concat "http://" op/site-domain)))
   (unless op/theme
-    (setq op/theme 'mdo)))
+    (setq op/theme 'mdo))
+  (unless op/highlight-render
+    (setq op/highlight-render 'js))
+  )
 
 (defun op/generate-readme (save-dir)
   "Generate README for `op/new-repository'. SAVE-DIR is the directory where to


### PR DESCRIPTION
Now we just **have** a `(setq op/highlight-render 'js/'htmlize)`,refer to #88