### PR TITLE
Customize Site Preview

### DIFF
--- a/doc/quick-guide.org
+++ b/doc/quick-guide.org
@@ -58,6 +58,16 @@
   it is recommended to execute this command via =M-x= since you
   will see more detailed options.
 
+** Site Preview
+
+If you'd like to preview your new post prior to publication, you can do this with
+
+: (op/do-publication-and-preview-site)
+
+After executing this command, your site will be published to the =op/site-preview-directory= which defaults to
+=~/.op-tmp= and will be served locally by [[https://github.com/skeeto/emacs-web-server][simple-httpd]]. The =op/site-preview-directory= variable is
+customizable. Be sure to read the documentation for =op/do-publication-and-preview-site= for even more options.
+
 * Helpful features
 
   1. Do you find that initializing a repository manually is too much trouble?

--- a/op-vars.el
+++ b/op-vars.el
@@ -131,13 +131,10 @@ org file's path, if parameter is nil, it should return all categories, the
 default value is `op/get-file-category'."
   :group 'org-page :type 'function)
 
-<<<<<<< HEAD
 (defcustom op/site-preview-directory "~/.op-tmp/"
   "Temporary directory path for site preview."
   :group 'org-page :type 'string)
 
-=======
->>>>>>> parent of 04d6f66... Add `op/site-preview-directory' user option.
 (defvar op/category-config-alist
   '(("blog" ;; this is the default configuration
     :show-meta t

--- a/op-vars.el
+++ b/op-vars.el
@@ -131,32 +131,35 @@ org file's path, if parameter is nil, it should return all categories, the
 default value is `op/get-file-category'."
   :group 'org-page :type 'function)
 
+<<<<<<< HEAD
 (defcustom op/site-preview-directory "~/.op-tmp/"
   "Temporary directory path for site preview."
   :group 'org-page :type 'string)
 
+=======
+>>>>>>> parent of 04d6f66... Add `op/site-preview-directory' user option.
 (defvar op/category-config-alist
   '(("blog" ;; this is the default configuration
-     :show-meta t
-     :show-comment t
-     :uri-generator op/generate-uri
-     :uri-template "/blog/%y/%m/%d/%t/"
-     :sort-by :date     ;; how to sort the posts
-     :category-index t) ;; generate category index or not
-    ("index"
-     :show-meta nil
-     :show-comment nil
-     :uri-generator op/generate-uri
-     :uri-template "/"
-     :sort-by :date
-     :category-index nil)
-    ("about"
-     :show-meta nil
-     :show-comment nil
-     :uri-generator op/generate-uri
-     :uri-template "/about/"
-     :sort-by :date
-     :category-index nil))
+    :show-meta t
+    :show-comment t
+    :uri-generator op/generate-uri
+    :uri-template "/blog/%y/%m/%d/%t/"
+    :sort-by :date     ;; how to sort the posts
+    :category-index t) ;; generate category index or not
+   ("index"
+    :show-meta nil
+    :show-comment nil
+    :uri-generator op/generate-uri
+    :uri-template "/"
+    :sort-by :date
+    :category-index nil)
+   ("about"
+    :show-meta nil
+    :show-comment nil
+    :uri-generator op/generate-uri
+    :uri-template "/about/"
+    :sort-by :date
+    :category-index nil))
   "Configurations for different categories, can and should be customized.")
 
 (defvar op/category-ignore-list

--- a/op-vars.el
+++ b/op-vars.el
@@ -131,28 +131,32 @@ org file's path, if parameter is nil, it should return all categories, the
 default value is `op/get-file-category'."
   :group 'org-page :type 'function)
 
+(defcustom op/site-preview-directory "~/.op-tmp"
+  "Temporary directory path for site preview."
+  :group 'org-page :type 'string)
+
 (defvar op/category-config-alist
   '(("blog" ;; this is the default configuration
-    :show-meta t
-    :show-comment t
-    :uri-generator op/generate-uri
-    :uri-template "/blog/%y/%m/%d/%t/"
-    :sort-by :date     ;; how to sort the posts
-    :category-index t) ;; generate category index or not
-   ("index"
-    :show-meta nil
-    :show-comment nil
-    :uri-generator op/generate-uri
-    :uri-template "/"
-    :sort-by :date
-    :category-index nil)
-   ("about"
-    :show-meta nil
-    :show-comment nil
-    :uri-generator op/generate-uri
-    :uri-template "/about/"
-    :sort-by :date
-    :category-index nil))
+     :show-meta t
+     :show-comment t
+     :uri-generator op/generate-uri
+     :uri-template "/blog/%y/%m/%d/%t/"
+     :sort-by :date     ;; how to sort the posts
+     :category-index t) ;; generate category index or not
+    ("index"
+     :show-meta nil
+     :show-comment nil
+     :uri-generator op/generate-uri
+     :uri-template "/"
+     :sort-by :date
+     :category-index nil)
+    ("about"
+     :show-meta nil
+     :show-comment nil
+     :uri-generator op/generate-uri
+     :uri-template "/about/"
+     :sort-by :date
+     :category-index nil))
   "Configurations for different categories, can and should be customized.")
 
 (defvar op/category-ignore-list

--- a/op-vars.el
+++ b/op-vars.el
@@ -131,7 +131,7 @@ org file's path, if parameter is nil, it should return all categories, the
 default value is `op/get-file-category'."
   :group 'org-page :type 'function)
 
-(defcustom op/site-preview-directory "~/.op-tmp/site/"
+(defcustom op/site-preview-directory "~/.op-tmp/"
   "Temporary directory path for site preview."
   :group 'org-page :type 'string)
 

--- a/op-vars.el
+++ b/op-vars.el
@@ -131,7 +131,7 @@ org file's path, if parameter is nil, it should return all categories, the
 default value is `op/get-file-category'."
   :group 'org-page :type 'function)
 
-(defcustom op/site-preview-directory "~/.op-tmp"
+(defcustom op/site-preview-directory "~/.op-tmp/site/"
   "Temporary directory path for site preview."
   :group 'org-page :type 'string)
 

--- a/org-page.el
+++ b/org-page.el
@@ -310,24 +310,18 @@ responsibility to guarantee the two parameters are valid."
                                   "add description here"))
     (save-buffer)))
 
-(defun op/do-publication-and-preview-site (path start-httpd)
-  "Do publication in PATH.
-
-If START-HTTPD is non-nil preview the site in the browser with simple-httpd.
+(defun op/do-publication-and-preview-site (path)
+  "Do publication in PATH and preview the site in the browser with simple-httpd.
 
 When invoked without prefix argument then PATH defaults to
-`op/site-preview-directory' and httpd is started."
+`op/site-preview-directory'."
   (interactive
    (if current-prefix-arg
-       (list (read-directory-name "Path: ")
-             (yes-or-no-p "Start httpd?"))
-       (list op/site-preview-directory t)))
+       (list (read-directory-name "Path: "))
+       (list op/site-preview-directory)))
   (op/do-publication t nil path)
-  (when start-httpd
-    (httpd-serve-directory path)
-    (browse-url (format "http://%s:%d" system-name httpd-port))))
-
-
+  (httpd-serve-directory path)
+  (browse-url (format "http://%s:%d" system-name httpd-port)))
 
 (provide 'org-page)
 

--- a/org-page.el
+++ b/org-page.el
@@ -310,12 +310,22 @@ responsibility to guarantee the two parameters are valid."
                                   "add description here"))
     (save-buffer)))
 
-(defun op/do-publication-and-preview-site ()
-  "Do publication in ~/.op-tmp and preview site in browser simple-httpd"
-  (interactive)
-  (op/do-publication t nil "~/.op-tmp/")
-  (httpd-serve-directory "~/.op-tmp/")
-  (browse-url (format "http://%s:%d" system-name httpd-port)))
+(defun op/do-publication-and-preview-site (path start-httpd)
+  "Do publication in PATH.
+
+If START-HTTPD is non-nil preview the site in the browser with simple-httpd.
+
+gWhen invoked without prefix argument then PATH defaults to
+`op/site-preview-directory' and httpd is started."
+  (interactive
+   (if current-prefix-arg
+       (list (read-directory-name "Path: ")
+             (yes-or-no-p "Start httpd?"))
+       (list op/site-preview-directory t)))
+  (op/do-publication t nil path)
+  (when start-httpd
+    (httpd-serve-directory path)
+    (browse-url (format "http://%s:%d" system-name httpd-port))))
 
 
 

--- a/org-page.el
+++ b/org-page.el
@@ -315,7 +315,7 @@ responsibility to guarantee the two parameters are valid."
 
 If START-HTTPD is non-nil preview the site in the browser with simple-httpd.
 
-gWhen invoked without prefix argument then PATH defaults to
+When invoked without prefix argument then PATH defaults to
 `op/site-preview-directory' and httpd is started."
   (interactive
    (if current-prefix-arg


### PR DESCRIPTION
Some customizations for the site preview:

1. Add some end user documentation
2. New `op/site-preview-directory` user option. This defaults to the `~/.op-temp/` folder. But I really think this should be customizable.
3. The `op/do-publication-and-site-preview` ask for the path and if httpd should be started when invoked with a prefix argument. Both defaults to `op/site-preview-directory` for the path and `t` for httpd start. 
