### PR TITLE
pass absolute store dir to `op/publish-changes`

### DIFF
--- a/org-page.el
+++ b/org-page.el
@@ -90,7 +90,7 @@ then the branch `op/repository-html-branch' will be pushed to remote repo."
   (let* ((orig-branch (op/git-branch-name op/repository-directory))
          (to-repo (not (stringp pub-base-dir)))
          (store-dir (if to-repo "~/.op-tmp/" pub-base-dir)) ; TODO customization
-         (store-dir-abs (expand-file-name store-dir))
+         (store-dir-abs (file-name-as-directory (expand-file-name store-dir)))
          changed-files all-files remote-repos)
     (op/git-change-branch op/repository-directory op/repository-org-branch)
     (op/prepare-theme store-dir)

--- a/org-page.el
+++ b/org-page.el
@@ -90,6 +90,7 @@ then the branch `op/repository-html-branch' will be pushed to remote repo."
   (let* ((orig-branch (op/git-branch-name op/repository-directory))
          (to-repo (not (stringp pub-base-dir)))
          (store-dir (if to-repo "~/.op-tmp/" pub-base-dir)) ; TODO customization
+         (store-dir-abs (expand-file-name store-dir))
          changed-files all-files remote-repos)
     (op/git-change-branch op/repository-directory op/repository-org-branch)
     (op/prepare-theme store-dir)
@@ -98,7 +99,7 @@ then the branch `op/repository-html-branch' will be pushed to remote repo."
                             `(:update ,all-files :delete nil)
                           (op/git-files-changed op/repository-directory
                                                 (or base-git-commit "HEAD~1"))))
-    (op/publish-changes all-files changed-files store-dir)
+    (op/publish-changes all-files changed-files store-dir-abs)
     (when to-repo
       (op/git-change-branch op/repository-directory op/repository-html-branch)
       (copy-directory store-dir op/repository-directory t t t)


### PR DESCRIPTION
Using an absolute directory prevents the relative path returned by `op/generate-uri` from resolving relative to the current buffer. This is an issue since the `string-to-file` is called while visiting each to be published site file.

For example, let's take:

```elisp
(setq op/category-config-alist 
      '(("blog" ...)
        ("index" ...)))

(op/do-publication t nil "_build" nil)
```

Results in a `_build` folder being created under the root directory _and_ the `blog` directory:

```shell
~/repos/jtmoulia.github.io-org-page $ tree -L 2
.
|-- LICENSE
|-- README
|-- _build
|   |-- about
|   |-- assets
|   |-- blog
|   |-- index.html
|   |-- media
|   `-- tags
|-- _buildrss.xml
|-- about.org
|-- assets
|   `-- img
|-- blog
|   |-- _build
|   |-- about-ob-elixir.org
|   |-- distrib-seq-diagram.org
|   |-- elixir_call_with_parens.org
|   |-- elixir_distel_basics.org
|   |-- intro_to_spell.org
|   |-- neotomex-intro.org
|   |-- norse_ipviking_map.org
|   `-- switchboard.org
|-- index.org
`-- jtmoulia-config.el
```