### PR TITLE
Feature : Category label

### DIFF
--- a/doc/quick-guide.org
+++ b/doc/quick-guide.org
@@ -116,6 +116,7 @@
      + =:sort-by=: how to sort posts on category index page, by
        =:date= or by =:mod-date=  (:mod-date is last modification date)?
      + =:category-index=: generate an index page for this category?
+     + =:label=: displayed label for the category (default: category folder name)
 
   10. Want to add an avatar to the page?
 

--- a/op-export.el
+++ b/op-export.el
@@ -326,7 +326,7 @@ file attribute property lists. PUB-BASE-DIR is the root publication directory."
                                       "container.mustache")))
              (ht ("header"
                   (op/render-header
-                   (ht ("page-title" (concat (capitalize (car cat-list))
+                   (ht ("page-title" (concat (op/get-category-name (car cat-list))
                                              " Index - "
                                              op/site-main-title))
                        ("author" (or user-full-name "Unknown Author")))))
@@ -334,7 +334,7 @@ file attribute property lists. PUB-BASE-DIR is the root publication directory."
                  ("content"
                   (op/render-content
                    "category-index.mustache"
-                   (ht ("cat-name" (capitalize (car cat-list)))
+                   (ht ("cat-name" (op/get-category-name (car cat-list)))
                        ("posts"
                         (mapcar
                          #'(lambda (attr-plist)

--- a/op-template.el
+++ b/op-template.el
@@ -62,6 +62,14 @@ BODY and push the result into cache and return it."
   `(or (op/get-cache-item ,key)
        (op/update-cache-item ,key (funcall (lambda () ,@body)))))
 
+(defun op/get-category-name (category)
+  "Return the name of the CATEGORY based on op/category-config-alist :label property. 
+Default to capitalized CATEGORY name if no :label property found."
+  (let* ((config (cdr (or (assoc category op/category-config-alist)
+                          (assoc "blog" op/category-config-alist)))))
+    (or (plist-get config :label)
+        (capitalize category))))
+
 (defun op/render-header (&optional param-table)
   "Render the header on each page. PARAM-TABLE is the hash table from mustache
 to render the template. If it is not set or nil, this function will try to build
@@ -101,7 +109,7 @@ render from a default hash table."
                         #'(lambda (cat)
                             (ht ("category-uri"
                                  (concat "/" (encode-string-to-url cat) "/"))
-                                ("category-name" (capitalize cat))))
+                                ("category-name" (op/get-category-name cat))))
                         (sort (remove-if
                                #'(lambda (cat)
                                    (or (string= cat "index")


### PR DESCRIPTION
[This commit fixes #163]
An optional :label property is now available to change the category
name. Ex :

(setq op/category-config-alist
      '(("reference"
         :label "Référence"  ;; <-- In French, accents are required
         :show-meta t
...))