### PR TITLE
Extract export backend to variable to allow other backends.

### DIFF
--- a/op-template.el
+++ b/op-template.el
@@ -147,9 +147,9 @@ similar to `op/render-header'. `op/highlight-render' is `js' or `htmlize'."
                                 #'(lambda (code lang)
                                     (when code
                                       (org-html-encode-plain-text code)))))
-                       (org-export-as op/export-method nil nil t nil))))
+                       (org-export-as op/export-backend nil nil t nil))))
                   ((eq op/highlight-render 'htmlize)
-                   (org-export-as op/export-method nil nil t nil))))))))
+                   (org-export-as op/export-backend nil nil t nil))))))))
 
 (defun op/render-footer (&optional param-table)
   "Render the footer on each page. PARAM-TABLE is similar to

--- a/op-template.el
+++ b/op-template.el
@@ -147,9 +147,9 @@ similar to `op/render-header'. `op/highlight-render' is `js' or `htmlize'."
                                 #'(lambda (code lang)
                                     (when code
                                       (org-html-encode-plain-text code)))))
-                       (org-export-as'html nil nil t nil))))
+                       (org-export-as op/export-method nil nil t nil))))
                   ((eq op/highlight-render 'htmlize)
-                   (org-export-as'html nil nil t nil))))))))
+                   (org-export-as op/export-method nil nil t nil))))))))
 
 (defun op/render-footer (&optional param-table)
   "Render the footer on each page. PARAM-TABLE is similar to

--- a/op-vars.el
+++ b/op-vars.el
@@ -52,8 +52,8 @@
 `op/repository-html-branch'."
   :group 'org-page :type 'string)
 
-(defcustom op/export-method 'html
-  "The org-export method used for page generation"
+(defcustom op/export-backend 'html
+  "The org-export backend used for page generation"
   :group 'org-page :type 'symbol)
 
 (defcustom op/site-domain nil

--- a/op-vars.el
+++ b/op-vars.el
@@ -52,6 +52,10 @@
 `op/repository-html-branch'."
   :group 'org-page :type 'string)
 
+(defcustom op/export-method 'html
+  "The org-export method used for page generation"
+  :group 'org-page :type 'symbol)
+
 (defcustom op/site-domain nil
   "The domain name of entire site, it is recommended to assign with prefix
 http:// or https://, http will be considered if not assigned."

--- a/org-page.el
+++ b/org-page.el
@@ -151,6 +151,7 @@ perfectly manipulated by org-page."
 `op/site-domain': <required>
 `op/personal-disqus-shortname': <optional>
 `op/personal-duoshuo-shortname': <optional>
+`op/export-method': [optional](default 'html)
 `op/repository-org-branch': [optional] (but customization recommended)
 `op/repository-html-branch': [optional] (but customization recommended)
 `op/site-main-title': [optional] (but customization recommanded)

--- a/org-page.el
+++ b/org-page.el
@@ -151,7 +151,7 @@ perfectly manipulated by org-page."
 `op/site-domain': <required>
 `op/personal-disqus-shortname': <optional>
 `op/personal-duoshuo-shortname': <optional>
-`op/export-method': [optional](default 'html)
+`op/export-backend': [optional](default 'html)
 `op/repository-org-branch': [optional] (but customization recommended)
 `op/repository-html-branch': [optional] (but customization recommended)
 `op/site-main-title': [optional] (but customization recommanded)


### PR DESCRIPTION
As the current export backend is hardcoded, this PR introduces a new customize variable with a default value of `'html`.

My motivation was wanting to use a derived backend from `ox-html` (specifically https://github.com/dakrone/ox-tufte), which previously wasn't possible. The default behaviour stays the same, so there shouldn't be any breaking changes.