### PR TITLE
Removes certain characters when generating URL.

### DIFF
--- a/op-util.el
+++ b/op-util.el
@@ -180,7 +180,7 @@ so do `trim-string-left' and `trim-string-right'."
   "Encode STRING to legal URL. Why we do not use `url-encode-url' to encode the
 string, is that `url-encode-url' will convert all not allowed characters into
 encoded ones, like %3E, but we do NOT want this kind of url."
-  (downcase (replace-regexp-in-string "[ :/\\]+" "-" string)))
+  (downcase (replace-regexp-in-string "[ .,:;/\\]+" "-" (replace-regexp-in-string "[.!?'\"]" "" (replace-regexp-in-string "[.!?]+$" "" string)))))
 
 (defun get-full-url (uri)
   "Get the full url of URI, by joining `op/site-domain' with URI."


### PR DESCRIPTION
Some post titles will have certain characters that should not be part of a URL. This commit removes these unwanted characters for a cleaner generated URL.

Take this hypothetical post title for example:

> What's up with"bagels"?: Aha! A complete guide."

The recent changes would generate the url:

> whats-up-with-bagels-aha-a-complete-guide

Before it generated the following:

>what's-up-with-\"bagels\"?-aha!-a-complete-guide.

I tested the other functions that uses the `encode-string-to-url` function. Everything seems to be working properly.

Tell me what you guys think. Or if there are other characters that should be removed when generating the URL.