### PR TITLE
Added support for hashover self-hosted commenting system.

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,7 +18,7 @@
   6) Search engine support (auto generated)
   7) A beautiful theme
   8) Theme customization support
-  9) Commenting (implemented using disqus/duoshuo)
+  9) Commenting (implemented using disqus/duoshuo/hashover)
   10) Website traffic analytics (implemented using google analytics)
   11) Index/about page support (auto generated if no default is provided)
   12) Site preview
@@ -64,9 +64,10 @@
    : (require 'org-page)
    : (setq op/repository-directory "path/to/your/org/repository")
    : (setq op/site-domain "http://your.personal.site.com/")
-   : ;;; for commenting, you can choose either disqus or duoshuo
+   : ;;; for commenting, you can choose either disqus, duoshuo or hashover
    : (setq op/personal-disqus-shortname "your_disqus_shortname")
    : (setq op/personal-duoshuo-shortname "your_duoshuo_shortname")
+   : (setq op/hashover-comments t)
    : ;;; the configuration below are optional
    : (setq op/personal-google-analytics-id "your_google_analytics_id")
 

--- a/doc/quick-guide.org
+++ b/doc/quick-guide.org
@@ -42,6 +42,7 @@
   : ;;; the configuration below you should choose one, not both
   : (setq op/personal-disqus-shortname "your_disqus_shortname")    ;; your disqus commenting system
   : (setq op/personal-duoshuo-shortname "your_duoshuo_shortname")  ;; your duoshuo commenting system
+  : (setq op/hashover-comments t)                                   ;; activate hashover self-hosted comment system
 
 * Publication
 

--- a/op-template.el
+++ b/op-template.el
@@ -200,6 +200,8 @@ similar to `op/render-header'. `op/highlight-render' is `js' or `htmlize'."
              ("author" (or (op/read-org-option "AUTHOR")
                            user-full-name
                            "Unknown Author"))
+	     ("hashover-comment" (and (boundp 'op/hashover-comments)
+				      op/hashover-comments))
              ("disqus-id" uri)
              ("disqus-url" (get-full-url uri))
              ("disqus-comment" (and (boundp 'op/personal-disqus-shortname)

--- a/op-vars.el
+++ b/op-vars.el
@@ -245,6 +245,12 @@ the date in the aaaa-mm-dd format. It should return a string
 representing the date in its new format."
   :group 'org-page :type 'function)
 
+(defcustom op/hashover-comments nil
+  "use hashover commenting system"
+  :group 'org-page
+  :type 'boolean)
+
+
 (provide 'op-vars)
 
 ;;; op-vars.el ends here

--- a/themes/mdo/templates/footer.mustache
+++ b/themes/mdo/templates/footer.mustache
@@ -42,6 +42,11 @@
           })();
         </script>
         {{/duoshuo-comment}}
+       {{#hashover-comment}}
+       <div id="hashover"></div>
+       <script type="text/javascript" src="/hashover.php"></script>
+       <noscript>You must have JavaScript enabled to use the comments.</noscript>
+       {{/hashover-comment}}
       </section>
       {{/show-comment}}
       <script src="//code.jquery.com/jquery-latest.min.js"></script>


### PR DESCRIPTION
- added a configuration variable `op/hashover-comments' to select hashover commenting system
- added support code in op-template.el
- added template example in mdo/templates/footer.mustache
- added minimal doc.

The proposed evolution supposes that you have installed hashover in the publishing directory.